### PR TITLE
Wrong method used for setEntityPositionToPlayer()

### DIFF
--- a/src/main/java/wecui/obfuscation/Obfuscation.java
+++ b/src/main/java/wecui/obfuscation/Obfuscation.java
@@ -108,7 +108,7 @@ public class Obfuscation implements InitializationFactory {
     }
 
     public static void setEntityPositionToPlayer(Minecraft mc, Entity entity) {
-        entity.d(getPlayerX(mc.g), getPlayerY(mc.g), getPlayerZ(mc.g));
+        entity.b(getPlayerX(mc.g), getPlayerY(mc.g), getPlayerZ(mc.g));
     }
 
     public NetClientHandler getNetClientHandler(EntityClientPlayerMP player) {


### PR DESCRIPTION
Your obfuscation seems either out of date or wrong, but entity.d() will _move_ the player an extra pair of coords.
It _adds_ the numbers instead of setting them. IE If you're on x:1 y:60 z:1, It'll get moved to x:2, y:120, z:2, to x:3, y:180, z:3 and so on.

You want to use entity.b(), which sets the coords in stead of adding them, and corresponds to the correct MCP name.
